### PR TITLE
make forget logic explicit

### DIFF
--- a/daq/gateway.py
+++ b/daq/gateway.py
@@ -104,7 +104,8 @@ class Gateway():
     def _scan_finalize(self, forget=True):
         if self._scan_monitor:
             nclosed = self._scan_monitor.stream() and not self._scan_monitor.stream().closed
-            LOGGER.info('TAP forget %s nclosed %s', forget, nclosed)
+            if nclosed != forget:
+                LOGGER.warning('TAP forget %s nclosed %s', forget, nclosed)
             if nclosed:
                 self.runner.monitor_forget(self._scan_monitor.stream())
                 self._scan_monitor.terminate()

--- a/daq/gateway.py
+++ b/daq/gateway.py
@@ -133,7 +133,7 @@ class Gateway():
 
     def _scan_complete(self):
         LOGGER.info('Gateway %d scan complete', self.port_set)
-        self._scan_finalize()
+        self._scan_finalize(forget=False)
 
     def _scan_error(self, e):
         LOGGER.error('Gateway %d monitor error: %s', self.port_set, e)

--- a/daq/gateway.py
+++ b/daq/gateway.py
@@ -101,10 +101,13 @@ class Gateway():
         self.activated = True
         self._scan_finalize()
 
-    def _scan_finalize(self):
+    def _scan_finalize(self, forget=True):
         if self._scan_monitor:
-            self.runner.monitor_forget(self._scan_monitor.stream())
-            self._scan_monitor.terminate()
+            nclosed = self._scan_monitor.stream() and not self._scan_monitor.stream().closed:
+            LOGGER.info('TAP forget %s nclosed %s' % (forget, nclosed))
+            if nclosed:
+                self.runner.monitor_forget(self._scan_monitor.stream())
+                self._scan_monitor.terminate()
             self._scan_monitor = None
 
     def allocate_test_port(self):

--- a/daq/gateway.py
+++ b/daq/gateway.py
@@ -104,9 +104,8 @@ class Gateway():
     def _scan_finalize(self, forget=True):
         if self._scan_monitor:
             nclosed = self._scan_monitor.stream() and not self._scan_monitor.stream().closed
-            if nclosed != forget:
-                LOGGER.warning('TAP forget %s nclosed %s', forget, nclosed)
-            if nclosed:
+            assert nclosed == forget, 'forget and nclosed mismatch'
+            if forget:
                 self.runner.monitor_forget(self._scan_monitor.stream())
                 self._scan_monitor.terminate()
             self._scan_monitor = None

--- a/daq/gateway.py
+++ b/daq/gateway.py
@@ -103,9 +103,8 @@ class Gateway():
 
     def _scan_finalize(self):
         if self._scan_monitor:
-            if self._scan_monitor.stream() and not self._scan_monitor.stream().closed:
-                self.runner.monitor_forget(self._scan_monitor.stream())
-                self._scan_monitor.terminate()
+            self.runner.monitor_forget(self._scan_monitor.stream())
+            self._scan_monitor.terminate()
             self._scan_monitor = None
 
     def allocate_test_port(self):

--- a/daq/gateway.py
+++ b/daq/gateway.py
@@ -104,7 +104,7 @@ class Gateway():
     def _scan_finalize(self, forget=True):
         if self._scan_monitor:
             nclosed = self._scan_monitor.stream() and not self._scan_monitor.stream().closed
-            LOGGER.info('TAP forget %s nclosed %s' % (forget, nclosed))
+            LOGGER.info('TAP forget %s nclosed %s', forget, nclosed)
             if nclosed:
                 self.runner.monitor_forget(self._scan_monitor.stream())
                 self._scan_monitor.terminate()

--- a/daq/gateway.py
+++ b/daq/gateway.py
@@ -103,7 +103,7 @@ class Gateway():
 
     def _scan_finalize(self, forget=True):
         if self._scan_monitor:
-            nclosed = self._scan_monitor.stream() and not self._scan_monitor.stream().closed:
+            nclosed = self._scan_monitor.stream() and not self._scan_monitor.stream().closed
             LOGGER.info('TAP forget %s nclosed %s' % (forget, nclosed))
             if nclosed:
                 self.runner.monitor_forget(self._scan_monitor.stream())

--- a/daq/host.py
+++ b/daq/host.py
@@ -362,9 +362,8 @@ class ConnectedHost:
     def _monitor_cleanup(self):
         if self._tcp_monitor:
             LOGGER.info('Target port %d monitor scan complete', self.target_port)
-            if self._tcp_monitor.stream() and not self._tcp_monitor.stream().closed:
-                self.runner.monitor_forget(self._tcp_monitor.stream())
-                self._tcp_monitor.terminate()
+            self.runner.monitor_forget(self._tcp_monitor.stream())
+            self._tcp_monitor.terminate()
             self._tcp_monitor = None
 
     def _monitor_error(self, exception):

--- a/daq/host.py
+++ b/daq/host.py
@@ -368,7 +368,7 @@ class ConnectedHost:
 
     def _monitor_error(self, exception):
         LOGGER.error('Target port %d monitor error: %s', self.target_port, exception)
-        self._monitor_cleanup()
+        self._monitor_cleanup(forget=False)
         self.record_result(self.test_name, exception=exception)
         self._state_transition(_STATE.ERROR)
         self.runner.target_set_error(self.target_port, exception)
@@ -400,7 +400,7 @@ class ConnectedHost:
 
     def _monitor_complete(self):
         LOGGER.info('Target port %d scan complete', self.target_port)
-        self._monitor_cleanup()
+        self._monitor_cleanup(forget=False)
         self.record_result('monitor', state=MODE.DONE)
         self._monitor_continue()
 

--- a/daq/host.py
+++ b/daq/host.py
@@ -363,9 +363,8 @@ class ConnectedHost:
         if self._tcp_monitor:
             LOGGER.info('Target port %d monitor scan complete', self.target_port)
             nclosed = self._tcp_monitor.stream() and not self._tcp_monitor.stream().closed
-            if nclosed != forget:
-                LOGGER.warning('TAP forget %s nclosed %s', forget, nclosed)
-            if nclosed:
+            assert nclosed == forget, 'forget and nclosed mismatch'
+            if forget:
                 self.runner.monitor_forget(self._tcp_monitor.stream())
                 self._tcp_monitor.terminate()
             self._tcp_monitor = None

--- a/daq/host.py
+++ b/daq/host.py
@@ -363,7 +363,8 @@ class ConnectedHost:
         if self._tcp_monitor:
             LOGGER.info('Target port %d monitor scan complete', self.target_port)
             nclosed = self._tcp_monitor.stream() and not self._tcp_monitor.stream().closed
-            LOGGER.info('TAP forget %s nclosed %s', forget, nclosed)
+            if nclosed != forget:
+                LOGGER.warning('TAP forget %s nclosed %s', forget, nclosed)
             if nclosed:
                 self.runner.monitor_forget(self._tcp_monitor.stream())
                 self._tcp_monitor.terminate()

--- a/daq/host.py
+++ b/daq/host.py
@@ -362,7 +362,7 @@ class ConnectedHost:
     def _monitor_cleanup(self, forget=True):
         if self._tcp_monitor:
             LOGGER.info('Target port %d monitor scan complete', self.target_port)
-            nclosed = self._tcp_monitor.stream() and not self._tcp_monitor.stream().closed:
+            nclosed = self._tcp_monitor.stream() and not self._tcp_monitor.stream().closed
             LOGGER.info('TAP forget %s nclosed %s' % (forget, nclosed))
             if nclosed:
                 self.runner.monitor_forget(self._tcp_monitor.stream())

--- a/daq/host.py
+++ b/daq/host.py
@@ -363,7 +363,7 @@ class ConnectedHost:
         if self._tcp_monitor:
             LOGGER.info('Target port %d monitor scan complete', self.target_port)
             nclosed = self._tcp_monitor.stream() and not self._tcp_monitor.stream().closed
-            LOGGER.info('TAP forget %s nclosed %s' % (forget, nclosed))
+            LOGGER.info('TAP forget %s nclosed %s', forget, nclosed)
             if nclosed:
                 self.runner.monitor_forget(self._tcp_monitor.stream())
                 self._tcp_monitor.terminate()

--- a/daq/host.py
+++ b/daq/host.py
@@ -359,11 +359,14 @@ class ConnectedHost:
             self._monitor_cleanup()
             self._monitor_error(e)
 
-    def _monitor_cleanup(self):
+    def _monitor_cleanup(self, forget=True):
         if self._tcp_monitor:
             LOGGER.info('Target port %d monitor scan complete', self.target_port)
-            self.runner.monitor_forget(self._tcp_monitor.stream())
-            self._tcp_monitor.terminate()
+            nclosed = self._tcp_monitor.stream() and not self._tcp_monitor.stream().closed:
+            LOGGER.info('TAP forget %s nclosed %s' % (forget, nclosed))
+            if nclosed:
+                self.runner.monitor_forget(self._tcp_monitor.stream())
+                self._tcp_monitor.terminate()
             self._tcp_monitor = None
 
     def _monitor_error(self, exception):


### PR DESCRIPTION
This makes the forget logic explicit, rather than deduced -- but also adds an assert to check consistency. So, if it every isn't correct then it should show up obvious-like.
